### PR TITLE
Fix CashAddr fallthrough bug (issue #2) — auto-prefix bare addresses

### DIFF
--- a/src/bitcoin.c
+++ b/src/bitcoin.c
@@ -40,10 +40,24 @@ bool validate_address(connsock_t *cs, const char *address, bool *script, bool *s
 	uint8_t hash160[20];
 	bool is_cashaddr = false;
 	bool is_p2sh = false;
+	char prefixed_addr[128];
 
 	if (unlikely(!address)) {
 		LOGWARNING("Null address passed to validate_address");
 		return ret;
+	}
+
+	/* AUTO-PREFIX FIX (SoloFury 2026-04-23):
+	 * Bare CashAddr starts with 'q' or 'p' and is 42 chars long.
+	 * Add the bitcoincash: prefix automatically so the decoder
+	 * can validate it correctly. */
+	if ((address[0] == 'q' || address[0] == 'p' ||
+	     address[0] == 'Q' || address[0] == 'P') &&
+	    strchr(address, ':') == NULL && strlen(address) >= 42) {
+		snprintf(prefixed_addr, sizeof(prefixed_addr),
+		         "bitcoincash:%s", address);
+		address = prefixed_addr;
+		LOGINFO("Auto-prefixed bare CashAddr in validate_address: %s", address);
 	}
 
 	/* Check if it's a CashAddr format */

--- a/src/libckpool.c
+++ b/src/libckpool.c
@@ -1823,11 +1823,24 @@ static int segaddress_to_txn(char *p2h, const char *addr)
 /* Convert an address to a transaction and return the length of the transaction */
 int address_to_txn(char *p2h, const char *addr, const bool script, const bool segwit)
 {
-	/* Check if it's a CashAddr format */
+	/* Check if it's a CashAddr format - WITH explicit prefix */
 	if (strncasecmp(addr, "bitcoincash:", 12) == 0 ||
 	    strncasecmp(addr, "bchtest:", 8) == 0 ||
 	    strncasecmp(addr, "bchreg:", 7) == 0) {
 		return cashaddr_to_script(addr, (uint8_t *)p2h);
+	}
+
+	/* AUTO-PREFIX FIX (SoloFury 2026-04-23):
+	 * Bare CashAddr (no prefix) starts with 'q' or 'p' and is 42 chars.
+	 * Without this fix, parser falls through to Base58 decoder which
+	 * silently produces wrong hash160 (no checksum validation). */
+	if ((addr[0] == 'q' || addr[0] == 'p' ||
+	     addr[0] == 'Q' || addr[0] == 'P') &&
+	    strchr(addr, ':') == NULL && strlen(addr) >= 42) {
+		char prefixed[128];
+		snprintf(prefixed, sizeof(prefixed), "bitcoincash:%s", addr);
+		LOGINFO("Auto-prefixed bare CashAddr: %s -> %s", addr, prefixed);
+		return cashaddr_to_script(prefixed, (uint8_t *)p2h);
 	}
 
 	if (segwit)


### PR DESCRIPTION
## Summary

Fixes #2 — bare CashAddr addresses (without explicit `bitcoincash:` prefix) silently fall through to the Base58 decoder, producing spurious hash160 bytes that get written into the coinbase scriptPubKey. Pool operators lose the entire block reward to a non-recoverable address.

## Background

Issue #2 (opened by @aaron3481, 5 months ago) reports block 927030 lost to this bug. I independently lost 3.126 BCH on April 20, 2026 (block 947633) to the same issue — coinbase reward sent to spurious hash160 `aef1328e1a44e182b07f812faf87269e3a50e0a2`, non-recoverable.

## Root Cause

In `libckpool.c::address_to_txn()` and `bitcoin.c::validate_address()`, the CashAddr parser only checks for explicit prefixes (`bitcoincash:`, `bchtest:`, `bchreg:`):

```c
if (strncasecmp(addr, "bitcoincash:", 12) == 0 ||
    strncasecmp(addr, "bchtest:", 8) == 0 ||
    strncasecmp(addr, "bchreg:", 7) == 0) {
    return cashaddr_to_script(addr, (uint8_t *)p2h);
}
// ↓ FALLTHROUGH for bare CashAddr
if (segwit) return segaddress_to_txn(p2h, addr);
if (script) return address_to_scripttxn(p2h, addr);
return address_to_pubkeytxn(p2h, addr);  // ← Base58 decoder
```

When a user provides a bare CashAddr like `qq3j0vlrpxc4h8ctgr8j4hkqcwu6u9jmhgcxkm6k5s` (which is what most miners copy from their wallet UI), the prefix check fails and execution falls through to `address_to_pubkeytxn()`, which interprets the CashAddr characters as Base58. The Base58 alphabet partially overlaps with CashAddr's, so decode succeeds and produces 20 garbage bytes that go straight into the coinbase scriptPubKey.

The pool considers the address valid, accepts shares normally, and only when a block is found does the reward go to a non-recoverable address.

## Fix

Detect bare CashAddr (starts with `q`/`p`/`Q`/`P`, no `:` separator, length ≥42 chars) and auto-prefix with `bitcoincash:` before delegating to the proper CashAddr parser.

## Files Changed

- `src/libckpool.c`: +14 lines in `address_to_txn()`
- `src/bitcoin.c`: +14 lines in `validate_address()`

No behavioral change for addresses with explicit prefixes. No external dependency changes.

## Production Validation

Patched binary deployed on solofury.com (BCH solo pool) on 2026-04-23.

- **MD5 (post-patch):** `5ab1a105c6146e2be99ef015010fb0bb`
- **Pre-patch MD5:** `fab280651d9f97e2ecdeda8dac27e601`
- **Production stats:** 27+ billion shares accepted, 0.10% reject rate (no regression)
- **Test client validation:** 10 different address formats tested (lower, UPPER, with/without prefix, mixed case) — all produce correct hash160s, verified by stratum-level coinbase parsing

## Backward Compatibility

- ✅ Addresses with explicit prefix (`bitcoincash:...`, `bchtest:...`, `bchreg:...`): unchanged behavior
- ✅ Legacy P2PKH addresses (`1...`): unchanged
- ✅ Legacy P2SH addresses (`3...`): unchanged
- ✅ Bech32 addresses (`bc1...`): unchanged (don't start with q/p)

The only behavioral change is that bare BCH CashAddr now decode correctly instead of producing garbage hash160s.

## Suggested Merge Strategy

This is a critical security fix — silent fund loss for pool operators with no error message or warning. I'd suggest merging directly to `master` and tagging a new release so downstream forks can pick it up.

Happy to split into smaller commits, add unit tests, or adjust the fix scope if you prefer a different approach.

---

Pool operators currently affected by this bug have two options:
1. Apply this patch
2. Switch all `btcaddress`/`pooladdress` config to legacy `1...` format

Either works as a workaround, but the patch is the correct long-term fix since miners (users) will continue to provide bare CashAddr in their config.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/skaisser/codesmith/ckpool/pr/4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/skaisser/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->